### PR TITLE
Cargo.toml, src: fix the building feature of the rand crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ structopt = { version = "0.3", optional = true }
 pest = "2.1"
 pest_derive = "2.1"
 thiserror = "1.0"
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 data-encoding = "2.3"
 data-encoding-macro = "0.1"
 regex-syntax = "0.6"

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -55,7 +55,6 @@ struct TableState<'a, W: Writer> {
 #[derive(Debug)]
 pub struct Env<'a, W: Writer> {
     state: &'a mut State,
-    qualified: bool,
     tables: Vec<TableState<'a, W>>,
 }
 
@@ -84,7 +83,6 @@ impl<'a, W: Writer> Env<'a, W> {
                 })
                 .collect::<Result<_, _>>()?,
             state,
-            qualified,
         })
     }
 


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

Try to build with v1.58.1, got errors:

![image](https://user-images.githubusercontent.com/1446531/152919811-413ffd30-df8e-460a-829e-afe0fbde86a9.png)

According to the [doc](https://docs.rs/rand/latest/rand/rngs/struct.OsRng.html), `OsRng` is supported on crate feature `getrandom` only. This PR fixes this.